### PR TITLE
Refactor GSM modem power control and add shell commands

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -22,6 +22,7 @@ LOG_MODULE_REGISTER(modem_gsm, CONFIG_MODEM_LOG_LEVEL);
 #include <drivers/modem/quectel.h>
 #include <drivers/uart.h>
 #include <drivers/console/uart_mux.h>
+#include <shell/shell.h>
 
 #include "gsm_ppp.h"
 #include "modem_context.h"
@@ -993,24 +994,26 @@ static void gsm_finalize_connection(struct k_work *work)
 		if (ret < 0) {
 			LOG_ERR("%s returned %d, %s", "AT", ret, "retrying...");
 
-			if (at_retry < 3) {
-				(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(1));
+			at_retry++;
+
+			if (at_retry <= 2) {
+				/* Simple retry with short delay */
+				(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(2));
 			} else if (at_retry == 3) {
-				disable_power_source(&gsm->context);
-				gsm->state = GSM_PPP_PWR_SRC_OFF;
-				(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(10));
+				/* First soft reboot with 1-minute backoff */
+				modem_soft_reboot();
+				LOG_INF("Waiting 1 minute for modem to recover...");
+				(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_MINUTES(1));
 			} else if (at_retry == 4) {
-				disable_power_source(&gsm->context);
-				gsm->state = GSM_PPP_PWR_SRC_OFF;
-				(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(20));
-			} else if (at_retry == 5) {
-				disable_power_source(&gsm->context);
-				gsm->state = GSM_PPP_PWR_SRC_OFF;
-				(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(30));
+				/* Second soft reboot with 5-minute backoff */
+				modem_soft_reboot();
+				LOG_INF("Waiting 5 minutes for modem to recover...");
+				(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_MINUTES(5));
 			} else {
+				/* All retries failed, trigger a system reboot */
+				LOG_ERR("All modem recovery attempts failed. Triggering system reboot.");
 				gmoc_reboot_cold(GMOC_GSM_AT_FAILED);
 			}
-			at_retry++;
 			goto unlock;
 		} else {
 			at_retry = 0;
@@ -1780,7 +1783,7 @@ static void gsm_configure(struct k_work *work)
 			gsm->modem_on_cb(gsm->dev, gsm->user_data);
 			gsm->state = GSM_PPP_WAIT_AT;
 		} else {
-			disable_power_source(&gsm->context);
+			disable_power_source();
 			gsm->state = GSM_PPP_PWR_SRC_OFF;
 			/* Arbitrary delay to drain the power */
 			(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(2));
@@ -1790,7 +1793,7 @@ static void gsm_configure(struct k_work *work)
 
 pwr_src_off:
 	if (gsm->state == GSM_PPP_PWR_SRC_OFF) {
-		enable_power_source(&gsm->context);
+		enable_power_source();
 		gsm->state = GSM_PPP_PWR_SRC_ON;
 		/* Arbitrary delay for the power to stabilize */
 		(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_SECONDS(2));
@@ -1799,7 +1802,7 @@ pwr_src_off:
 
 pwr_src_on:
 	if (gsm->state == GSM_PPP_PWR_SRC_ON) {
-		power_on_ops(&gsm->context);
+		power_on_ops();
 		gsm->state = GSM_PPP_WAIT_AT;
 		/* The unsol 'RDY' handler will schedule the following part */
 		goto unlock;
@@ -1974,8 +1977,8 @@ void gsm_ppp_stop(const struct device *dev)
 	if (gsm->modem_off_cb) {
 		gsm->modem_off_cb(gsm->dev, gsm->user_data);
 	} else {
-		power_off_ops(&gsm->context);
-		disable_power_source(&gsm->context);
+		power_off_ops();
+		disable_power_source();
 	}
 
 	gsm->gnss_state = PPP_GNSS_OFF;
@@ -2059,9 +2062,27 @@ static int gsm_init(const struct device *dev)
 	gsm->gsm_data.rx_rb_buf = &gsm->gsm_rx_rb_buf[0];
 	gsm->gsm_data.rx_rb_buf_len = sizeof(gsm->gsm_rx_rb_buf);
 
-#if HAS_PWR_SRC || HAS_PWR_KEY
-	gsm->context.pins = modem_pins;
-	gsm->context.pins_len = ARRAY_SIZE(modem_pins);
+#if HAS_PWR_SRC
+	if (!device_is_ready(modem_power_src.port)) {
+		LOG_ERR("Power source GPIO device not ready");
+		return -ENODEV;
+	}
+	r = gpio_pin_configure_dt(&modem_power_src, GPIO_OUTPUT_INACTIVE);
+	if (r < 0) {
+		LOG_ERR("Failed to configure power source GPIO: %d", r);
+		return r;
+	}
+#endif
+#if HAS_PWR_KEY
+	if (!device_is_ready(modem_power_key.port)) {
+		LOG_ERR("Power key GPIO device not ready");
+		return -ENODEV;
+	}
+	r = gpio_pin_configure_dt(&modem_power_key, GPIO_OUTPUT_INACTIVE);
+	if (r < 0) {
+		LOG_ERR("Failed to configure power key GPIO: %d", r);
+		return r;
+	}
 #endif
 
 	r = modem_iface_uart_init(&gsm->context.iface, &gsm->gsm_data,
@@ -2121,3 +2142,36 @@ static int gsm_init(const struct device *dev)
 
 DEVICE_DT_DEFINE(DT_INST(0, zephyr_gsm_ppp), gsm_init, NULL, &gsm, NULL, POST_KERNEL,
 		 CONFIG_MODEM_GSM_INIT_PRIORITY, NULL);
+
+static int cmd_gsm_power(const struct shell *shell, size_t argc, char **argv)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_INST(0, zephyr_gsm_ppp));
+
+	if (argc < 2) {
+		shell_error(shell, "Missing argument. Use 'on', 'off', or 'reboot'.");
+		return -ENOEXEC;
+	}
+
+	if (strcmp(argv[1], "on") == 0) {
+		shell_print(shell, "Executing GSM power ON sequence...");
+		gsm_ppp_start(dev);
+	} else if (strcmp(argv[1], "off") == 0) {
+		shell_print(shell, "Executing GSM power OFF sequence...");
+		gsm_ppp_stop(dev);
+	} else if (strcmp(argv[1], "reboot") == 0) {
+		shell_print(shell, "Executing GSM soft reboot...");
+		modem_soft_reboot();
+	} else {
+		shell_error(shell, "Invalid argument: %s. Use 'on', 'off', or 'reboot'.", argv[1]);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_gsm,
+			       SHELL_CMD_ARG(power, NULL, "Control GSM power (on|off|reboot)",
+					     cmd_gsm_power, 2, 0),
+			       SHELL_SUBCMD_SET_END);
+
+SHELL_CMD_REGISTER(gsm, &sub_gsm, "GSM modem commands", NULL);

--- a/drivers/modem/gsm_ppp.h
+++ b/drivers/modem/gsm_ppp.h
@@ -15,32 +15,14 @@
 #define HAS_PWR_SRC DT_INST_NODE_HAS_PROP(0, power_src_gpios)
 #define HAS_PWR_KEY DT_INST_NODE_HAS_PROP(0, power_key_gpios)
 
-#if HAS_PWR_SRC || HAS_PWR_KEY
-/* pin settings */
-enum mdm_control_pins {
 #if HAS_PWR_SRC
-	MDM_PWR_SRC,
+static const struct gpio_dt_spec modem_power_src =
+    GPIO_DT_SPEC_GET(DT_DRV_INST(0), power_src_gpios);
 #endif
 #if HAS_PWR_KEY
-	MDM_PWR_KEY,
+static const struct gpio_dt_spec modem_power_key =
+    GPIO_DT_SPEC_GET(DT_DRV_INST(0), power_key_gpios);
 #endif
-};
-
-/* Modem pins - Power, Reset & others. */
-static struct modem_pin modem_pins[] = {
-#if HAS_PWR_SRC
-	/* MDM_POWER SUPPLY */
-	MODEM_PIN(DT_INST_GPIO_LABEL(0, power_src_gpios), DT_INST_GPIO_PIN(0, power_src_gpios),
-		  DT_INST_GPIO_FLAGS(0, power_src_gpios) | GPIO_OUTPUT_LOW),
-#endif
-
-#if HAS_PWR_KEY
-	/* MDM_POWER_KEY */
-	MODEM_PIN(DT_INST_GPIO_LABEL(0, power_key_gpios), DT_INST_GPIO_PIN(0, power_key_gpios),
-		  DT_INST_GPIO_FLAGS(0, power_key_gpios) | GPIO_OUTPUT_LOW),
-#endif
-};
-#endif /* HAS_PWR_SRC || HAS_PWR_KEY */
 
 /**
  * @brief  Disable power source of the modem.
@@ -49,10 +31,12 @@ static struct modem_pin modem_pins[] = {
  *
  * @retval None.
  */
-void disable_power_source(struct modem_context *ctx)
+static inline void disable_power_source(void)
 {
 #if HAS_PWR_SRC
-	modem_pin_write(ctx, MDM_PWR_SRC, 0);
+    if (modem_power_src.port) {
+        gpio_pin_set_dt(&modem_power_src, 0);
+    }
 #endif
 }
 
@@ -63,19 +47,23 @@ void disable_power_source(struct modem_context *ctx)
  *
  * @retval None.
  */
-void enable_power_source(struct modem_context *ctx)
+static inline void enable_power_source(void)
 {
 #if HAS_PWR_SRC
-	modem_pin_write(ctx, MDM_PWR_SRC, 1);
+    if (modem_power_src.port) {
+        gpio_pin_set_dt(&modem_power_src, 1);
+    }
 #endif
 }
 
 #if HAS_PWR_KEY
-static void press_power_key(struct modem_context *ctx, const k_timeout_t dur)
+static void press_power_key(k_timeout_t dur)
 {
-	modem_pin_write(ctx, MDM_PWR_KEY, 1);
-	k_sleep(dur);
-	modem_pin_write(ctx, MDM_PWR_KEY, 0);
+    if (modem_power_key.port) {
+        gpio_pin_set_dt(&modem_power_key, 1);
+        k_sleep(dur);
+        gpio_pin_set_dt(&modem_power_key, 0);
+    }
 }
 #endif
 
@@ -86,10 +74,10 @@ static void press_power_key(struct modem_context *ctx, const k_timeout_t dur)
  *
  * @retval None.
  */
-void power_on_ops(struct modem_context *ctx)
+static inline void power_on_ops(void)
 {
 #if DT_INST_NODE_HAS_PROP(0, power_key_on_ms)
-	press_power_key(ctx, K_MSEC(DT_INST_PROP(0, power_key_on_ms)));
+    press_power_key(K_MSEC(DT_INST_PROP(0, power_key_on_ms)));
 #endif
 }
 
@@ -100,10 +88,32 @@ void power_on_ops(struct modem_context *ctx)
  *
  * @retval None.
  */
-void power_off_ops(struct modem_context *ctx)
+static inline void power_off_ops(void)
 {
 #if DT_INST_NODE_HAS_PROP(0, power_key_off_ms)
-	press_power_key(ctx, K_MSEC(DT_INST_PROP(0, power_key_off_ms)));
+    press_power_key(K_MSEC(DT_INST_PROP(0, power_key_off_ms)));
+#endif
+}
+
+/**
+ * @brief  Perform a soft reboot of the modem.
+ *
+ * This function powers the modem off using the power key, waits,
+ * and then powers it back on.
+ *
+ * @retval None.
+ */
+static inline void modem_soft_reboot(void)
+{
+#if HAS_PWR_KEY
+    LOG_WRN("Performing modem soft reboot...");
+    power_off_ops();
+    /* Wait for modem to power down completely */
+    k_sleep(K_SECONDS(5));
+    power_on_ops();
+    LOG_INF("Modem soft reboot sequence complete.");
+#else
+    LOG_WRN("Soft reboot not supported, no power key defined.");
 #endif
 }
 


### PR DESCRIPTION
Replaces context-based power control functions with direct GPIO operations and introduces modem_soft_reboot for soft reboots. Adds shell command support for GSM power management (on, off, reboot). Improves retry logic for modem recovery and updates initialization to configure GPIOs directly.